### PR TITLE
chore(gems): Remove edifact_tools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in ruby_gkv_billing.gemspec
 gemspec
 
-gem 'edifact_tools', git: "https://github.com/Skulli/edifact_tools.git"
+# gem 'edifact_tools', git: "https://github.com/Skulli/edifact_tools.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/Skulli/edifact_tools.git
-  revision: 8aed8176bae0d01df1f34fba59fee61f9319dcfc
-  specs:
-    edifact_tools (0.1.0)
-
 PATH
   remote: .
   specs:
@@ -39,10 +33,9 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
-  edifact_tools!
   rake (~> 10.0)
   rspec (~> 3.0)
   ruby_gkv_billing!
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/lib/ruby_gkv_billing/provider.rb
+++ b/lib/ruby_gkv_billing/provider.rb
@@ -1,5 +1,5 @@
 # https://www.gkv-datenaustausch.de/media/dokumente/leistungserbringer_1/sonstige_leistungserbringer/technische_anlagen_aktuell_4/Anhang_03_Anlage_1_TP5_20200408.pdf
-require 'edifact_tools'
+# require 'edifact_tools'
 
 module RubyGkvBilling
   class Provider

--- a/lib/ruby_gkv_billing/provider_file.rb
+++ b/lib/ruby_gkv_billing/provider_file.rb
@@ -1,6 +1,6 @@
 # Kostentraegerdatei
 # https://www.gkv-datenaustausch.de/media/dokumente/leistungserbringer_1/sonstige_leistungserbringer/technische_anlagen_aktuell_4/Anhang_03_Anlage_1_TP5_20200408.pdfhttps://www.gkv-datenaustausch.de/media/dokumente/standards_und_normen/technische_spezifikationen/Anlage_2_-_Auftragsdatei.pdf
-require 'edifact_tools'
+# require 'edifact_tools'
 
 module RubyGkvBilling
   class ProviderFile


### PR DESCRIPTION
Quickfix as I don't use the provider file stuff and the gem-repo is private now.